### PR TITLE
Update to support gh-pages

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: RFC Template
+nav_order: 3
+---
+
 - Feature Name: (fill me in with a unique identifier, my_awesome_feature)
 - Start Date: (fill me in with today's date, YYYY-MM-DD)
 - RFC PR: (leave this empty)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: RFCs Process
+nav_order: 2
+---
 # Hyperledger Fabric RFCs Process
 
 Many changes, including bug fixes and documentation improvements can be

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+remote_theme: pmarsceill/just-the-docs

--- a/index.md
+++ b/index.md
@@ -1,0 +1,15 @@
+---
+layout: default
+title: Hyperledger Fabric RFCs
+nav_order: 1
+---
+
+# RFCs 
+
+The RFC (request for comments) process is intended to provide a consistent and
+controlled path for major changes to Fabric and other official project
+components, so that all stakeholders can be confident about the direction in
+which Fabric is evolving.
+
+- [Template](0000-template.md)
+- [Process](README.md)

--- a/rfcs.md
+++ b/rfcs.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: RFCs
+has_children: true
+nav_order: 3
+---
+
+# List of RFCs

--- a/text/0000-chaincode-go-new-programming-model.md
+++ b/text/0000-chaincode-go-new-programming-model.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: chaincode_go_new_programming_model
+parent: RFCs
+---
+
 - Feature Name: chaincode_go_new_programming_model
 - Start Date: 2019-11-15
 - RFC PR:

--- a/text/0000-dummy.md
+++ b/text/0000-dummy.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: RFC Template
+parent: RFCs
+---
+
 - Feature Name: (fill me in with a unique identifier, my_awesome_feature)
 - Start Date: (fill me in with today's date, YYYY-MM-DD)
 - RFC PR: (leave this empty)


### PR DESCRIPTION
This PR contains some minor updates to permit the use of
gh-pages to render the RFCs. This provides better
rendering of the RFCs (we can alter this in future to
further improve).  Free text-search is also now available

Changes are

- a defined theme in the config file
- minmal set of pages to define a hierachy
- Only effect to RFCs is the requirement to add minor
  front matter

Note: github repo admins will need to enable the gh-page
feature on repo settings. The source should be set to 'master branch'
with no theme chosen.

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>