### PR TITLE
Update link to the issues tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,11 +204,11 @@ a comment describing the rationale for the decision.
 Some accepted RFCs represent vital changes that need to be implemented right
 away. Other accepted RFCs can represent changes that can wait until a
 developer feels like doing the work. Every accepted RFC has an associated
-issue tracking its implementation in the [Fabric JIRA issue tracker](https://jira.hyperledger.org/projects/FAB/issues).
+issue tracking its implementation in the [Fabric issues](github.com/hyperledger/fabric/issues).
 
 The author of an RFC is not obligated to implement it. Of course, the RFC
 author, as any other developer, is welcome to post an implementation for review
-after the RFC has been accepted. Use JIRA for this.
+after the RFC has been accepted. Use GitHub issues for this.
 
 ## License
 


### PR DESCRIPTION
Since we no longer use JIRA, we updated the link to reflect the actual issue tracker.